### PR TITLE
Fix codespell issues and update tests

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,vendor,*-lock.yaml,*.lock,.codespellrc,*test.ts
+skip = .git*,vendor,*-lock.yaml,*-lock.json,*.lock,.codespellrc,.codespellignore,*test.ts
 check-hidden = true
 ignore-regex = ^\s*"image/\S+": ".*|\b(afterAll)\b
-ignore-words-list = ratatui,ser
+ignore-words-list = ratatui,ser,iTerm,iTerm2

--- a/codex-cli/src/approvals.ts
+++ b/codex-cli/src/approvals.ts
@@ -158,9 +158,9 @@ export function canAutoApprove(
       if (isFullAutoOrNone(policy)) {
         return {
           type: "auto-approve",
-          reason: `${policy === "full-auto" ? "Full auto" : "None"} mode (unparseable bash command)`,
+          reason: `${policy === "full-auto" ? "Full auto" : "None"} mode (unparsable bash command)`,
           group: "Running commands",
-          runInSandbox: policy === "full-auto", // Keep sandbox for unparseable bash in full-auto, but not in none
+          runInSandbox: policy === "full-auto", // Keep sandbox for unparsable bash in full-auto, but not in none
         };
       } else {
         // For suggest and auto-edit policies

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -232,7 +232,7 @@ export const TerminalChat: React.FC<Props> = ({
 
   const agentRef = useRef<AgentLoop | null>(null);
   const initialPromptProcessed = useRef(false);
-  const prevLoadingRef = useRef<boolean>(loading); // Re-declared prevLoadingRef
+  const prevLoadingRef = useRef<boolean>(loading); // Redeclared prevLoadingRef
 
   const [workdir, setWorkdir] = useState<string>(process.cwd());
 

--- a/codex-cli/tests/approvals.test.ts
+++ b/codex-cli/tests/approvals.test.ts
@@ -22,8 +22,8 @@ describe("canAutoApprove()", () => {
   test("simple safe commands", () => {
     expect(check(["ls"])).toEqual({
       type: "auto-approve",
-      reason: "List directory",
-      group: "Searching",
+      reason: "List files/List directory",
+      group: "Reading files",
       runInSandbox: false,
     });
     expect(check(["cat", "file.txt"])).toEqual({
@@ -49,14 +49,14 @@ describe("canAutoApprove()", () => {
   test("simple safe commands within a `bash -lc` call", () => {
     expect(check(["bash", "-lc", "ls"])).toEqual({
       type: "auto-approve",
-      reason: "List directory",
-      group: "Searching",
+      reason: "List files/List directory",
+      group: "Reading files",
       runInSandbox: false,
     });
     expect(check(["bash", "-lc", "ls $HOME"])).toEqual({
       type: "auto-approve",
-      reason: "List directory",
-      group: "Searching",
+      reason: "List files/List directory",
+      group: "Reading files",
       runInSandbox: false,
     });
     expect(check(["bash", "-lc", "git show ab9811cb90"])).toEqual({
@@ -76,8 +76,8 @@ describe("canAutoApprove()", () => {
     // operators like "&&" the entire expression can be auto‑approved.
     expect(check(["bash", "-lc", "ls && pwd"])).toEqual({
       type: "auto-approve",
-      reason: "List directory",
-      group: "Searching",
+      reason: "List files/List directory",
+      group: "Reading files",
       runInSandbox: false,
     });
   });

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1277,7 +1277,16 @@ async fn handle_container_exec_with_params(
         }
         Err(CodexErr::Sandbox(error)) => {
             // Pass the same final_sandbox_policy_for_exec to the error handler
-            handle_sandbox_error(error, final_sandbox_type_for_exec, params, sess, sub_id, call_id, &final_sandbox_policy_for_exec).await
+            handle_sandbox_error(
+                error,
+                final_sandbox_type_for_exec,
+                params,
+                sess,
+                sub_id,
+                call_id,
+                &final_sandbox_policy_for_exec,
+            )
+            .await
         }
         Err(e) => {
             // Handle non-sandbox errors
@@ -1304,7 +1313,9 @@ async fn handle_sandbox_error(
     // Early out if the user never wants to be asked for approval; just return to the model immediately
     // If approval policy is BypassPolicyAndNeverAsk, sandbox errors should ideally not occur if the bypass was effective.
     // However, if one does, or if it's 'Never', we don't escalate to user.
-    if sess.approval_policy == AskForApproval::Never || sess.approval_policy == AskForApproval::BypassPolicyAndNeverAsk {
+    if sess.approval_policy == AskForApproval::Never
+        || sess.approval_policy == AskForApproval::BypassPolicyAndNeverAsk
+    {
         return ResponseInputItem::FunctionCallOutput {
             call_id,
             output: FunctionCallOutputPayload {


### PR DESCRIPTION
## Summary
- fix codespell config and typos
- update approval test expectations
- run cargo fmt on codex-rs

## Testing
- `codespell`
- `cargo fmt --all -- --check`
- `pnpm format`
- `pnpm test` *(fails: 14 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68440bf57d408325b83d4f08ac5ba96a