### PR TITLE
Remove debug logging

### DIFF
--- a/codex-cli/src/components/chat/multiline-editor.tsx
+++ b/codex-cli/src/components/chat/multiline-editor.tsx
@@ -53,14 +53,6 @@ proto["emit"] = function patchedEmit(
 ): boolean {
   if (event === "data") {
     const chunk = args[0] as string;
-
-    if (
-      process.env["TEXTBUFFER_DEBUG"] === "1" ||
-      process.env["TEXTBUFFER_DEBUG"] === "true"
-    ) {
-      // eslint-disable-next-line no-console
-      console.log("[MultilineTextEditor:stdin] data", JSON.stringify(chunk));
-    }
     // Store carriage returns as‑is so that Ink can distinguish between plain
     // <Enter> ("\r") and a bare line‑feed ("\n").  This matters because Ink's
     // `parseKeypress` treats "\r" as key.name === "return", whereas "\n" maps
@@ -201,14 +193,6 @@ const MultilineTextEditorInner = (
     (input, key) => {
       if (!focus) {
         return;
-      }
-
-      if (
-        process.env["TEXTBUFFER_DEBUG"] === "1" ||
-        process.env["TEXTBUFFER_DEBUG"] === "true"
-      ) {
-        // eslint-disable-next-line no-console
-        console.log("[MultilineTextEditor] event", { input, key });
       }
 
       // 1a) CSI-u / modifyOtherKeys *mode 2* (Ink strips initial ESC, so we

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -276,10 +276,6 @@ export const TerminalChat: React.FC<Props> = ({
         commandForConfirmation: Array<string>,
         applyPatch: ApplyPatchCommand | undefined,
       ): Promise<CommandConfirmation> => {
-        console.log(
-          `[Codex Debug] TerminalChat.getCommandConfirmation: approvalPolicy state is '${approvalPolicy}'`,
-        );
-
         // Always auto-approve commands in full-auto or none modes
         // Handle both "full-auto" (code) and "full_auto" (UI) formats
         if (


### PR DESCRIPTION
## Summary
- strip unnecessary console.log calls from MultilineTextEditor
- remove debug print from TerminalChat

## Testing
- `pnpm --filter @openai/codex run format`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_68443633cc208325b61e46cb31a9a8fe