### PR TITLE
Remove stray comments

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -153,7 +153,6 @@ export const TerminalChat: React.FC<Props> = ({
   fullStdout,
 }: Props): React.ReactElement => {
   useEffect(() => {
-    // Debug logging disabled
   }, [approvalPolicy]);
 
   const notify = Boolean(config.notify);
@@ -226,13 +225,12 @@ export const TerminalChat: React.FC<Props> = ({
     _initialPromptFromProps,
   );
   const [currentImagePaths, setCurrentImagePaths] = useState(
-    // Renamed state variable
     _initialImagePathsFromProps, // Initialized with the prop value
   );
 
   const agentRef = useRef<AgentLoop | null>(null);
   const initialPromptProcessed = useRef(false);
-  const prevLoadingRef = useRef<boolean>(loading); // Redeclared prevLoadingRef
+  const prevLoadingRef = useRef<boolean>(loading);
 
   const [workdir, setWorkdir] = useState<string>(process.cwd());
 


### PR DESCRIPTION
## Summary
- remove leftover comments from terminal-chat.tsx

## Testing
- `pnpm --filter @openai/codex run lint` *(fails: ESLint errors)*
- `pnpm --filter @openai/codex run typecheck` *(fails: TypeScript errors)*
- `pnpm --filter @openai/codex run test` *(fails: 14 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68443634b3d88325a55fa9e102061bdd