### PR TITLE
Use AutoApprovalMode constants

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -13,6 +13,7 @@ import type {
   ApplyPatchCommand,
   SafetyAssessment,
 } from "../../approvals.js";
+import { AutoApprovalMode } from "../../utils/auto-approval-mode.js";
 import type { AppConfig } from "../../utils/config.js";
 import type {
   ResponseItem,
@@ -171,8 +172,9 @@ export const TerminalChat: React.FC<Props> = ({
 
   const colorsByPolicy: Record<string, string | undefined> = {
     "full-auto": "green",
+    [AutoApprovalMode.FULL_AUTO]: "green",
+    [AutoApprovalMode.NONE]: "red",
     "needs-confirmation": "yellow",
-    "none": "red",
     "manual": "cyan",
   };
 
@@ -281,11 +283,10 @@ export const TerminalChat: React.FC<Props> = ({
         );
 
         // Always auto-approve commands in full-auto or none modes
-        // Handle both "full-auto" (code) and "full_auto" (UI) formats
         if (
           approvalPolicy === "full-auto" ||
-          approvalPolicy === "full_auto" ||
-          approvalPolicy === "none"
+          approvalPolicy === AutoApprovalMode.FULL_AUTO ||
+          approvalPolicy === AutoApprovalMode.NONE
         ) {
           // Only reject commands that have been explicitly marked as reject
           if (safetyAssessment.type === "reject") {


### PR DESCRIPTION
## Summary
- reuse `AutoApprovalMode` enum in approval logic
- use enum values when checking approval mode in the UI

## Testing
- `pnpm test` *(fails: `vitest` not found)*
- `pnpm --filter @openai/codex run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68443635c6288325a93c7e01d3e9ee40