### PR TITLE
Enable JS files in TypeScript config

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,13 @@ The hardening mechanism Codex uses depends on your OS:
 
 ## System requirements
 
-| Requirement                 | Details                                                         |
-| --------------------------- | --------------------------------------------------------------- |
-| Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11 **via WSL2** |
-| Node.js                     | **22 or newer** (LTS recommended)                               |
-| Git (optional, recommended) | 2.23+ for built-in PR helpers                                   |
-| RAM                         | 4-GB minimum (8-GB recommended)                                 |
+| Requirement                 | Details                                                            |
+| --------------------------- | ------------------------------------------------------------------ |
+| Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11 **via WSL2**    |
+| Node.js                     | **22 or newer** (LTS recommended)                                  |
+|                             | If your system defaults to an older Node version, run `nvm use 22` |
+| Git (optional, recommended) | 2.23+ for built-in PR helpers                                      |
+| RAM                         | 4-GB minimum (8-GB recommended)                                    |
 
 > Never run `sudo npm install -g`; fix npm permissions instead.
 

--- a/codex-cli/tsconfig.json
+++ b/codex-cli/tsconfig.json
@@ -14,6 +14,7 @@
     "resolveJsonModule": true, // ESM doesn't yet support JSON modules.
     "esModuleInterop": true,
     "jsx": "react",
+    "allowJs": true,
     "declaration": true,
     "newLine": "lf",
     "stripInternal": true,


### PR DESCRIPTION
## Summary
- allow js sources in codex-cli tsconfig

## Testing
- `pnpm test` *(fails: vitest run)*
- `pnpm run lint` *(fails: eslint src tests)*
- `node codex-cli/bin/codex.js hi` *(prompts for sign-in)*

------
https://chatgpt.com/codex/tasks/task_e_68455f494f288325ab4e5fb5d23c3602