### PR TITLE
Add web access toggle to CLI

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -48,6 +48,7 @@ export interface TerminalChatInputProps {
   openHelpOverlay: () => void;
   openDiffOverlay: () => void;
   openSessionsOverlay: () => void;
+  openWebOverlay: () => void;
   onCompact: () => void;
   items: Array<ResponseInputItem>;
   workdir?: string;
@@ -68,6 +69,7 @@ export default function TerminalChatInput({
   openHelpOverlay,
   openDiffOverlay,
   openSessionsOverlay,
+  openWebOverlay,
   onCompact,
   items = [],
   workdir,
@@ -213,6 +215,10 @@ export default function TerminalChatInput({
             openApprovalOverlay();
             return;
           }
+          if (command.command === "/web") {
+            openWebOverlay();
+            return;
+          }
           if (command.command === "/sessions") {
             openSessionsOverlay();
             return;
@@ -259,6 +265,7 @@ export default function TerminalChatInput({
       openModelOverlay,
       openProviderOverlay,
       openApprovalOverlay,
+      openWebOverlay,
       openSessionsOverlay,
       setLastResponseId,
       submitInput,

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -51,6 +51,7 @@ import HelpOverlay from "../help-overlay.js";
 import HistoryOverlay from "../history-overlay.js";
 import ModelOverlay from "../model-overlay.js";
 import SessionsOverlay from "../sessions-overlay.js";
+import WebAccessOverlay from "../web-access-overlay.js";
 import chalk from "chalk";
 import fs from "fs/promises";
 import { Box, useStdout } from "ink";
@@ -67,6 +68,7 @@ export type OverlayModeType =
   | "model"
   | "provider"
   | "approval"
+  | "web"
   | "diff"
   | "help";
 
@@ -171,6 +173,7 @@ export const TerminalChat: React.FC<Props> = ({
   const [lastResponseId, setLastResponseId] = useState<string | null>(null);
   const [items, setItems] = useState<Array<ResponseItem>>([]);
   const [loading, setLoading] = useState<boolean>(false);
+  const [webAccess, setWebAccess] = useState<boolean>(config.webAccess ?? false);
 
   const [, forceRender] = useState(0);
   const forceUpdate = () => forceRender((c) => c + 1);
@@ -490,6 +493,7 @@ export const TerminalChat: React.FC<Props> = ({
     agent: agentRef.current ?? undefined,
     initialImagePaths: currentImagePaths, // Use renamed state variable for header
     flexModeEnabled: config.flexMode,
+    webAccessEnabled: webAccess,
     workdir: workdir,
   };
 
@@ -597,6 +601,7 @@ export const TerminalChat: React.FC<Props> = ({
           openHelpOverlay={() => setOverlayMode("help")}
           openDiffOverlay={() => setOverlayMode("diff")}
           openSessionsOverlay={() => setOverlayMode("sessions")}
+          openWebOverlay={() => setOverlayMode("web")}
           onCompact={handleCompact}
           items={safeItems}
           workdir={workdir}
@@ -839,6 +844,17 @@ export const TerminalChat: React.FC<Props> = ({
               return;
             }
             setOverlayMode("none");
+          }}
+          onExit={() => setOverlayMode("none")}
+        />
+      )}
+
+      {overlayMode === "web" && (
+        <WebAccessOverlay
+          enabled={webAccess}
+          onToggle={(val) => {
+            setWebAccess(val);
+            saveConfig({ ...config, webAccess: val });
           }}
           onExit={() => setOverlayMode("none")}
         />

--- a/codex-cli/src/components/chat/terminal-header.tsx
+++ b/codex-cli/src/components/chat/terminal-header.tsx
@@ -15,6 +15,7 @@ export interface TerminalHeaderProps {
   agent?: AgentLoop;
   initialImagePaths?: Array<string>;
   flexModeEnabled?: boolean;
+  webAccessEnabled?: boolean;
   workdir?: string;
 }
 
@@ -29,6 +30,7 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
   agent,
   initialImagePaths,
   flexModeEnabled = false,
+  webAccessEnabled = false,
   workdir,
 }) => {
   return (
@@ -39,6 +41,8 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
           ● Codex v{version} - {PWD} - {model} ({provider}) -{" "}
           <Text color={colorsByPolicy[approvalPolicy]}>{approvalPolicy}</Text>
           {flexModeEnabled ? " - flex-mode" : ""}
+          {" - web_access:"}
+          {webAccessEnabled ? "enabled" : "disabled"}
         </Text>
       ) : (
         <>
@@ -79,6 +83,10 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
               <Text bold color={colorsByPolicy[approvalPolicy]}>
                 {approvalPolicy}
               </Text>
+            </Text>
+            <Text dimColor>
+              <Text color="blueBright">↳</Text> web_access:{" "}
+              <Text bold>{webAccessEnabled ? "enabled" : "disabled"}</Text>
             </Text>
             {flexModeEnabled && (
               <Text dimColor>

--- a/codex-cli/src/components/web-access-overlay.tsx
+++ b/codex-cli/src/components/web-access-overlay.tsx
@@ -1,0 +1,34 @@
+import { Box, Text, useInput } from "ink";
+import React from "react";
+
+export default function WebAccessOverlay({
+  enabled,
+  onToggle,
+  onExit,
+}: {
+  enabled: boolean;
+  onToggle: (value: boolean) => void;
+  onExit: () => void;
+}): JSX.Element {
+  useInput((input, key) => {
+    if (input === "y") {
+      onToggle(true);
+      onExit();
+    } else if (input === "n" || key.escape) {
+      onToggle(false);
+      onExit();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="gray" width={60}>
+      <Box paddingX={1}>
+        <Text bold>Web access</Text>
+      </Box>
+      <Box flexDirection="column" paddingX={1}>
+        <Text>Currently {enabled ? "enabled" : "disabled"}.</Text>
+        <Text>Enable web access? (y/n)</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -199,6 +199,8 @@ export interface StoredConfig {
   /** Disable server-side response storage (send full transcript each request) */
   disableResponseStorage?: boolean;
   flexMode?: boolean;
+  /** Enable web search capabilities */
+  webAccess?: boolean;
   providers?: Record<string, { name: string; baseURL: string; envKey: string; defaultModel?: string; }>;
   history?: {
     maxSize?: number;
@@ -253,6 +255,8 @@ export type AppConfig = {
 
   /** Enable the "flex-mode" processing mode for supported models (o3, o4-mini) */
   flexMode?: boolean;
+  /** Enable web search capabilities */
+  webAccess?: boolean;
   providers?: Record<string, { name: string; baseURL: string; envKey: string; defaultModel: string }>;
   history?: {
     maxSize: number;
@@ -556,6 +560,12 @@ export const loadConfig = (
   if (storedConfig.flexMode !== undefined) {
     config.flexMode = storedConfig.flexMode;
   }
+  // Web access setting: enable web search when set in config
+  if (storedConfig.webAccess !== undefined) {
+    config.webAccess = storedConfig.webAccess;
+  } else {
+    config.webAccess = false;
+  }
 
   // Add default history config if not provided
   if (storedConfig.history !== undefined) {
@@ -644,6 +654,7 @@ export const saveConfig = (
     approvalMode: config.approvalMode,
     disableResponseStorage: config.disableResponseStorage,
     flexMode: config.flexMode,
+    webAccess: config.webAccess,
     reasoningEffort: config.reasoningEffort,
     providerApiKeys: config.providerApiKeys,
   };

--- a/codex-cli/src/utils/responses.ts
+++ b/codex-cli/src/utils/responses.ts
@@ -291,11 +291,13 @@ const createCompletion = (
   // ); // Log model for brevity
   const fullMessages = getFullMessages(input);
   const chatTools = convertTools(input.tools);
-  const webSearchOptions = input.tools?.some(
-    (tool) => tool.type === "function" && tool.name === "web_search",
-  )
-    ? {}
-    : undefined;
+  const webSearchOptions =
+    sessionConfig?.webAccess &&
+    input.tools?.some(
+      (tool) => tool.type === "function" && tool.name === "web_search",
+    )
+      ? {}
+      : undefined;
 
   const chatInput: OpenAI.Chat.Completions.ChatCompletionCreateParams = {
     model: input.model,

--- a/codex-cli/src/utils/slash-commands.ts
+++ b/codex-cli/src/utils/slash-commands.ts
@@ -91,4 +91,5 @@ export const SLASH_COMMANDS: Array<SlashCommand> = [
       );
     },
   },
+  { command: "/web", description: "Toggle web access" },
 ];


### PR DESCRIPTION
## Summary
- add `webAccess` to config
- show `web_access` status in terminal header
- enable `/web` command to toggle web access via overlay
- respect `webAccess` when creating completions

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457bd93de08325b9fec9eaf9bbb1a4